### PR TITLE
Compile with gcc5.4 (Ubuntu 16.04) needs c++14

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -138,6 +138,9 @@ win32-msvc* {
 
         # Linux Flex compiler grumbles about unsigned comparisons
         QMAKE_CXXFLAGS += -Wno-sign-compare
+
+        # Ubuntu 16.04 with gcc-5.4.0, it does not compile, unless c++ 2014 is set
+        CONFIG += c++14
     }
 }
 


### PR DESCRIPTION
Setting compilerflag c++14 for gcc-5.4.0 (Ubuntu16.04), according: https://gcc.gnu.org/projects/cxx-status.html
"Nested namespace definitions" are supported with gcc-6.x

Without this flag I get errors like this:
Cloud/CloudService.h:587:65: error: ‘CloudService::CloudServiceSetting’ is not a class or namespace
                 value = returning->settings.value(CloudService::CloudServiceSetting::DefaultURL, "");